### PR TITLE
Improve travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 ---
-sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.6.3
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0
 before_install:
-  - gem install bundler -v 2.0.2
+  - gem install bundler
   - bundle install
 script:
   - bundle exec rubocop


### PR DESCRIPTION
:wave: 

Thanks for the gem, small fixes on the travis side :)

* sudo: false is deprecated on travis
* the gem doesn't mention ruby support, so potentially there should be more versions here but I think last 3 minors so shortly after 2.7 release is reasonable
* locking bundler to a certain version shouldn't be needed